### PR TITLE
`func_score_to_gpm` works with scores for amino acid variants

### DIFF
--- a/dms_tools2/codonvarianttable.py
+++ b/dms_tools2/codonvarianttable.py
@@ -2865,8 +2865,8 @@ def func_score_to_gpm(func_scores_df, wildtype, metric='func_score'):
     Args:
         `func_scores_df` (functional score dataframe)
             A functional score dataframe (from the
-            `CodonVariantTable.func_scores` method), narrowed down to one post
-            sample condition, typically with something like:
+            :meth:`CodonVariantTable.func_scores` method), narrowed down to one
+            post sample condition, typically with something like:
             `func_scores_df.query('library == @library & sample == @sample')`
         `wildtype` (str)
             A string containing the wildtype sequence

--- a/dms_tools2/codonvarianttable.py
+++ b/dms_tools2/codonvarianttable.py
@@ -2859,7 +2859,7 @@ def codonSubsToSeq(wildtype, codon_subs, return_aa=False, aa_subs=False):
         return ''.join(CODON_TO_AA[codon] for codon in codon_list)
 
 
-def func_score_to_gpm(func_scores_df, wildtype, metric='func_score'):
+def func_score_to_gpm(func_scores_df, wildtype, metric='func_score', aaSubs=False):
     """Generate a gpm from a functinoal score dataframe.
 
     Args:
@@ -2871,6 +2871,14 @@ def func_score_to_gpm(func_scores_df, wildtype, metric='func_score'):
             A string containing the wildtype sequence
         'metric' (str)
             A string specifying which metric to use as a phenotype
+        'aaSubs' (bool)
+            Boolian value specifying whether to use amino acid substitutions
+            rather than codon substitutions to determine mutant genotypes
+            to put into the genotype phenotyep map. Use this option if you are
+            converting a func_scores_aa dataframe and want the average phenotype
+            of each same amino acid mutant to be put into the gpm rather than
+            the same amino acid mutants being put in several times with each
+            measured phenotype.
 
     Returns:
          A genotype phenotype map object from the Harms lab gpm package,
@@ -2884,16 +2892,19 @@ def func_score_to_gpm(func_scores_df, wildtype, metric='func_score'):
     stdev = np.sqrt(var)
 
     # Get codon substitutions in a list
-    codon_subs = func_scores_df['codon_substitutions'].tolist()
+    if aaSubs:
+        substitutions = func_scores_df['aa_substitutions'].tolist()
+    else:
+        substitutions = func_scores_df['codon_substitutions'].tolist()
 
     # Get a list of genotypes
     genotypes = []
-    for subs in codon_subs:
-        genotype = codonSubsToSeq(wildtype, subs, return_aa=True)
+    for subs in substitutions:
+        genotype = codonSubsToSeq(wildtype, subs, return_aa=True, aa_subs=aaSubs)
         genotypes.append(genotype)
 
     # Get the wildtype amino acid sequence
-    wildtype = codonSubsToSeq(wildtype, '', return_aa=True)
+    wildtype = codonSubsToSeq(wildtype, '', return_aa=True, aa_subs=aaSubs)
 
     # Generate the genotype phenotype map
     gpm = gpmap.GenotypePhenotypeMap(wildtype=wildtype, genotypes=genotypes,

--- a/dms_tools2/codonvarianttable.py
+++ b/dms_tools2/codonvarianttable.py
@@ -2859,7 +2859,7 @@ def codonSubsToSeq(wildtype, codon_subs, return_aa=False, aa_subs=False):
         return ''.join(CODON_TO_AA[codon] for codon in codon_list)
 
 
-def func_score_to_gpm(func_scores_df, wildtype, metric='func_score', by_aa=False):
+def func_score_to_gpm(func_scores_df, wildtype, metric='func_score'):
     """Generate a genotype phenotype map from a functional score dataframe.
 
     Args:
@@ -2872,16 +2872,10 @@ def func_score_to_gpm(func_scores_df, wildtype, metric='func_score', by_aa=False
             A string containing the wildtype sequence
         `metric` (str)
             A string specifying which metric to use as a phenotype
-        `by_aa` (bool)
-            Boolian value specifying whether functional scores were calculated
-            using `CodonVariantTable.func_scores` with the input
-            `by='aa_substitutions'`. If True, the genotype phenotype map will
-            contain the average phenotype of each mutant with identical amino
-            acid substitutions, rather than containing the phenotype of each
-            barcode variant.
 
     Returns:
-         A genotype phenotype map object from the Harms lab gpm package,
+         A genotype phenotype map object from the Harms lab
+         `gpmap package <https://github.com/harmslab/gpmap>`_
          to be used as in input into epistasis models in the epistasis package.
     """
     # Put the phenotypes into a list
@@ -2892,19 +2886,16 @@ def func_score_to_gpm(func_scores_df, wildtype, metric='func_score', by_aa=False
     stdev = np.sqrt(var)
 
     # Get codon substitutions in a list
-    if by_aa:
-        substitutions = func_scores_df['aa_substitutions'].tolist()
-    else:
-        substitutions = func_scores_df['codon_substitutions'].tolist()
+    substitutions = func_scores_df['aa_substitutions'].tolist()
 
     # Get a list of genotypes
     genotypes = []
     for subs in substitutions:
-        genotype = codonSubsToSeq(wildtype, subs, return_aa=True, aa_subs=by_aa)
+        genotype = codonSubsToSeq(wildtype, subs, return_aa=True, aa_subs=True)
         genotypes.append(genotype)
 
     # Get the wildtype amino acid sequence
-    wildtype = codonSubsToSeq(wildtype, '', return_aa=True, aa_subs=by_aa)
+    wildtype = codonSubsToSeq(wildtype, '', return_aa=True)
 
     # Generate the genotype phenotype map
     gpm = gpmap.GenotypePhenotypeMap(wildtype=wildtype, genotypes=genotypes,

--- a/dms_tools2/codonvarianttable.py
+++ b/dms_tools2/codonvarianttable.py
@@ -2787,8 +2787,8 @@ def codonSubsToSeq(wildtype, codon_subs, return_aa=False, aa_subs=False):
             Default is nucleotide.
         `aa_subs` (bool)
             Specify whether the substitutions are in amino acid form
-            rather than codon. Default is codon. return_aa must be True
-            in order for aa_subs to be True, since there are numerous
+            rather than codon. Default is codon. `return_aa` must be True
+            in order for `aa_subs` to be True, since there are numerous
             possible nucleotide sequences for an amino acid sequence.
 
     Returns:
@@ -2859,7 +2859,7 @@ def codonSubsToSeq(wildtype, codon_subs, return_aa=False, aa_subs=False):
         return ''.join(CODON_TO_AA[codon] for codon in codon_list)
 
 
-def func_score_to_gpm(func_scores_df, wildtype, metric='func_score', aaSubs=False):
+def func_score_to_gpm(func_scores_df, wildtype, metric='func_score', by_aa=False):
     """Generate a genotype phenotype map from a functional score dataframe.
 
     Args:
@@ -2872,14 +2872,13 @@ def func_score_to_gpm(func_scores_df, wildtype, metric='func_score', aaSubs=Fals
             A string containing the wildtype sequence
         `metric` (str)
             A string specifying which metric to use as a phenotype
-        `aaSubs` (bool)
-            Boolian value specifying whether to use amino acid substitutions
-            rather than codon substitutions to determine mutant genotypes
-            to put into the genotype phenotyep map. Use this option if you are
-            converting a func_scores_aa dataframe and want the average phenotype
-            of each same amino acid mutant to be put into the gpm rather than
-            the same amino acid mutants being put in several times with each
-            measured phenotype.
+        `by_aa` (bool)
+            Boolian value specifying whether functional scores were calculated
+            using `CodonVariantTable.func_scores` with the input
+            `by='aa_substitutions'`. If True, the genotype phenotype map will
+            contain the average phenotype of each mutant with identical amino
+            acid substitutions, rather than containing the phenotype of each
+            barcode variant.
 
     Returns:
          A genotype phenotype map object from the Harms lab gpm package,
@@ -2893,7 +2892,7 @@ def func_score_to_gpm(func_scores_df, wildtype, metric='func_score', aaSubs=Fals
     stdev = np.sqrt(var)
 
     # Get codon substitutions in a list
-    if aaSubs:
+    if by_aa:
         substitutions = func_scores_df['aa_substitutions'].tolist()
     else:
         substitutions = func_scores_df['codon_substitutions'].tolist()
@@ -2901,11 +2900,11 @@ def func_score_to_gpm(func_scores_df, wildtype, metric='func_score', aaSubs=Fals
     # Get a list of genotypes
     genotypes = []
     for subs in substitutions:
-        genotype = codonSubsToSeq(wildtype, subs, return_aa=True, aa_subs=aaSubs)
+        genotype = codonSubsToSeq(wildtype, subs, return_aa=True, aa_subs=by_aa)
         genotypes.append(genotype)
 
     # Get the wildtype amino acid sequence
-    wildtype = codonSubsToSeq(wildtype, '', return_aa=True, aa_subs=aaSubs)
+    wildtype = codonSubsToSeq(wildtype, '', return_aa=True, aa_subs=by_aa)
 
     # Generate the genotype phenotype map
     gpm = gpmap.GenotypePhenotypeMap(wildtype=wildtype, genotypes=genotypes,

--- a/dms_tools2/codonvarianttable.py
+++ b/dms_tools2/codonvarianttable.py
@@ -2777,19 +2777,19 @@ def codonSubsToSeq(wildtype, codon_subs, return_aa=False, aa_subs=False):
     """Convert codon substitutions to sequence.
 
     Args:
-        'wildtype' (str)
+        `wildtype` (str)
             The wildtype sequence
-        'codon_subs' (str)
+        `codon_subs` (str)
             String of space delimited codon substitutions, in the format:
             OldCodonSiteNewCodon
-        'return_aa' (bool)
+        `return_aa` (bool)
             Specify whether to return sequence as nucleotide or amino acid.
             Default is nucleotide.
-        'aa_subs' (bool)
+        `aa_subs` (bool)
             Specify whether the substitutions are in amino acid form
             rather than codon. Default is codon. return_aa must be True
             in order for aa_subs to be True, since there are numerous
-            possible nucleotide sequences for an amino acid sequence. 
+            possible nucleotide sequences for an amino acid sequence.
 
     Returns:
         A str of the sequence with all the codon substitutions
@@ -2804,7 +2804,7 @@ def codonSubsToSeq(wildtype, codon_subs, return_aa=False, aa_subs=False):
     'GGGCAGCAA'
     """
     # Make sure you are not trying to convert amino acids to codons
-    if aa_subs: 
+    if aa_subs:
         if not return_aa==True:
             raise ValueError('Cannot return nucleotide sequence using aa subs')
     # Make sure the wildtype sequence is divisible into codons
@@ -2860,18 +2860,19 @@ def codonSubsToSeq(wildtype, codon_subs, return_aa=False, aa_subs=False):
 
 
 def func_score_to_gpm(func_scores_df, wildtype, metric='func_score', aaSubs=False):
-    """Generate a gpm from a functinoal score dataframe.
+    """Generate a genotype phenotype map from a functional score dataframe.
 
     Args:
-        'func_scores_df' (functional score dataframe)
-            A functional score dataframe, narrowed down to one
-            post sample condition, typically with something like:
+        `func_scores_df` (functional score dataframe)
+            A functional score dataframe (from the
+            `CodonVariantTable.func_scores` method), narrowed down to one post
+            sample condition, typically with something like:
             `func_scores_df.query('library == @library & sample == @sample')`
-        'wildtype' (str)
+        `wildtype` (str)
             A string containing the wildtype sequence
-        'metric' (str)
+        `metric` (str)
             A string specifying which metric to use as a phenotype
-        'aaSubs' (bool)
+        `aaSubs` (bool)
             Boolian value specifying whether to use amino acid substitutions
             rather than codon substitutions to determine mutant genotypes
             to put into the genotype phenotyep map. Use this option if you are


### PR DESCRIPTION
Previously, the function would only be able to make a genotype phenotype map where each barcode variant is put into the map with its measured phenotype, regardless of whether some were actually the same amino acid mutant. Now, the function has the option to make a map where identical amino acid mutants are only put into the map once with their average phenotype. 
