### PR TITLE
added `diffsel.beta_diversity` function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Change Log
 ===========
 
+2.4.16
+------
+* Added `diffsel.beta_diversity`
+
 2.4.15
 ---------
 * Relax dependency requirements for `pysam`

--- a/dms_tools2/_metadata.py
+++ b/dms_tools2/_metadata.py
@@ -1,4 +1,4 @@
-__version__ = '2.4.15'
+__version__ = '2.4.16'
 __author__ = '`the Bloom Lab <https://github.com/jbloomlab/dms_tools2/graphs/contributors>`_'
 __url__ = 'http://jbloomlab.github.io/dms_tools2'
 __author_email__ = 'jbloom@fredhutch.org'

--- a/dms_tools2/diffsel.py
+++ b/dms_tools2/diffsel.py
@@ -82,64 +82,66 @@ def beta_diversity(tidy_df, *, samplecol, sitecol, valcol,
     The value is relatively high because sample `c` is a lot different
     than `a` and `b`:
 
-    >>> round(beta_diversity(tidy_df,
+    >>> scipy.allclose(beta_diversity(tidy_df,
     ...                      samplecol='sample',
     ...                      sitecol='site',
     ...                      valcol='positive_diffsel',
     ...                      index='shannon'),
-    ...       4)
-    1.4914
+    ...                1.4914, atol=1e-4)
+    True
 
     If we repeat the same using the Simpson index we get a higher
     diversity because the large-selection sites (which are up-weighted by
     Simpson index relative to Shannon) are diferent between `c` and `a` / `b`:
 
-    >>> round(beta_diversity(tidy_df,
+    >>> scipy.allclose(beta_diversity(tidy_df,
     ...                      samplecol='sample',
     ...                      sitecol='site',
     ...                      valcol='positive_diffsel',
     ...                      index='simpson'),
-    ...       4)
-    1.6478
+    ...                1.6478, atol=1e-4)
+    True
 
     If we calculate the beta diversity of just samples `a` and `b`, we
     get a smaller value because those samples are quite similar:
 
-    >>> round(beta_diversity(tidy_df.query('sample in ["a", "b"]'),
+    >>> scipy.allclose(beta_diversity(tidy_df.query('sample in ["a", "b"]'),
     ...                      samplecol='sample',
     ...                      sitecol='site',
     ...                      valcol='positive_diffsel',
     ...                      index='shannon'),
-    ...       4)
-    1.0022
+    ...                1.0022, atol=1e-4)
+    True
 
     Here the Simpson index gives lower diversity than the Shannon since
     `a` and `b` share the largest selection site:
 
-    >>> round(beta_diversity(tidy_df.query('sample in ["a", "b"]'),
+    >>> scipy.allclose(beta_diversity(tidy_df.query('sample in ["a", "b"]'),
     ...                      samplecol='sample',
     ...                      sitecol='site',
     ...                      valcol='positive_diffsel',
     ...                      index='simpson'),
-    ...       4)
-    1.0008
+    ...                1.0008, atol=1e-4)
+    True
 
     And of course the beta diversity of two identical samples is one:
 
-    >>> round(beta_diversity(pandas.concat([a_df, a_df.assign(sample='a2')]),
+    >>> scipy.allclose(beta_diversity(
+    ...                      pandas.concat([a_df, a_df.assign(sample='a2')]),
     ...                      samplecol='sample',
     ...                      sitecol='site',
     ...                      valcol='positive_diffsel',
     ...                      index='shannon'),
-    ...       4)
-    1.0
-    >>> round(beta_diversity(pandas.concat([a_df, a_df.assign(sample='a2')]),
+    ...                1, atol=1e-4)
+    True
+    >>> scipy.allclose(beta_diversity(
+    ...                      pandas.concat([a_df, a_df.assign(sample='a2')]),
     ...                      samplecol='sample',
     ...                      sitecol='site',
     ...                      valcol='positive_diffsel',
     ...                      index='simpson'),
-    ...       4)
-    1.0
+    ...                1, atol=1e-4)
+    True
 
     """
     cols = [samplecol, sitecol, valcol]


### PR DESCRIPTION
This function makes it possible to compute beta diversity
as a measure of how different selection is across samples.
This is useful if we want to see if there is more variation
of the sites of selection in one set of samples versus another.