### PR TITLE
Added `--bcinfo_csv` argument to `dms2_bcsubamp`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Change Log
 ===========
 
+2.6.4
+------
+* Added `--bcinfo_csv` option to `dms2_bcsubamp`.
+
 2.6.3
 ------
 * Edited `syn_selection` to add pseudocounts for odds ratio calculations in order to avoid null/inf values.

--- a/dms_tools2/_metadata.py
+++ b/dms_tools2/_metadata.py
@@ -1,4 +1,4 @@
-__version__ = '2.6.3'
+__version__ = '2.6.4'
 __author__ = '`the Bloom Lab <https://github.com/jbloomlab/dms_tools2/graphs/contributors>`_'
 __url__ = 'http://jbloomlab.github.io/dms_tools2'
 __author_email__ = 'jbloom@fredhutch.org'

--- a/dms_tools2/parseargs.py
+++ b/dms_tools2/parseargs.py
@@ -183,10 +183,13 @@ def bcsubampParentParser():
             help=("Randomly purge barcodes with this probability to "
             "subsample data."))
 
-    parser.set_defaults(bcinfo=False)
+    parser.set_defaults(bcinfo=False, bcinfo_csv=False)
     parser.add_argument('--bcinfo', dest='bcinfo', action='store_true',
             help=("Create file with suffix 'bcinfo.txt.gz' with info "
             "about each barcode."))
+    parser.add_argument('--bcinfo_csv', dest='bcinfo_csv',
+            action='store_true', help=("Store 'bcinfo' file as a csv "
+            "with the suffix 'bcinfo.csv.gz'."))
 
     return parser
 

--- a/dms_tools2/parseargs.py
+++ b/dms_tools2/parseargs.py
@@ -189,7 +189,8 @@ def bcsubampParentParser():
             "about each barcode."))
     parser.add_argument('--bcinfo_csv', dest='bcinfo_csv',
             action='store_true', help=("Store 'bcinfo' file as a csv "
-            "with the suffix 'bcinfo.csv.gz'."))
+            "with the suffix 'bcinfo.csv.gz'. Only has an effect if "
+            "`--bcinfo` is used."))
 
     return parser
 

--- a/scripts/dms2_batch_bcsubamp
+++ b/scripts/dms2_batch_bcsubamp
@@ -132,7 +132,7 @@ def main():
                     newargs.append('--{0}'.format(arg))
                     if isinstance(val, list):
                         newargs += list(map(str, val))
-                    elif arg != 'bcinfo':
+                    elif (arg != 'bcinfo') & (arg != 'bcinfo_csv'):
                         newargs.append(str(val))
             argslist.append(newargs)
         pool = multiprocessing.dummy.Pool(ncpus)

--- a/scripts/dms2_bcsubamp
+++ b/scripts/dms2_bcsubamp
@@ -208,8 +208,7 @@ def main():
                 zip(r1files, r2files)])))
 
         # collect reads by barcode while iterating over reads
-        logger.info("Now parsing read pairs test3...")
-        logger.info("here2")
+        logger.info("Now parsing read pairs...")
         nreads = {
                 'total':0,
                 'fail filter':0,

--- a/scripts/dms2_bcsubamp
+++ b/scripts/dms2_bcsubamp
@@ -45,7 +45,7 @@ def bcInfo(bc, bcreads, retained, consensus, desc, to_csv):
         num_R1 = len(bcreads['R1'])
         num_R2 = len(bcreads['R2'])
         return(','.join([bc, str(retained), desc, str(consensus),
-                        str(num_R1), str(num_R2)]))
+                        str(num_R1), str(num_R2)+'\n']))
     else:
         return '\n'.join([
                 'BARCODE: {0}'.format(bc),
@@ -321,7 +321,7 @@ def main():
 
         if args['bcinfo_csv']:
             bcinfofile.write("Barcode,Retained,Description,Consensus,"
-                             "R1_Count,R2_Count")
+                             "R1_Count,R2_Count\n")
 
         for (ibc, (bc, bcreads)) in enumerate(barcodes.items()):
 

--- a/scripts/dms2_bcsubamp
+++ b/scripts/dms2_bcsubamp
@@ -17,7 +17,7 @@ import dms_tools2.utils
 
 
 
-def bcInfo(bc, bcreads, retained, consensus, desc):
+def bcInfo(bc, bcreads, retained, consensus, desc, to_csv):
     """Returns string for writing to `bcinfofile`.
    
     Creates a string summarizing the barcode.
@@ -33,19 +33,29 @@ def bcInfo(bc, bcreads, retained, consensus, desc):
             The consensus sequence for the barcode if created.
         `desc` (str)
             String describing the barcode and its fate.
+        `to_csv` (bool)
+            If `to_csv` is `True`, outputs the barcode info as a
+            comma-delimited string. This string only retains the *number* of
+            reads for R1 and R2, not the actual reads.
 
     Returns:
         A string summarizing the barcode.
     """
-    return '\n'.join([
-            'BARCODE: {0}'.format(bc),
-            'RETAINED: {0}'.format(retained),
-            'DESCRIPTION: {0}'.format(desc),
-            'CONSENSUS: {0}'.format(consensus),
-            'R1 READS:\n\t{0}'.format('\n\t'.join(bcreads['R1'])),
-            'R2 READS:\n\t{0}'.format('\n\t'.join(bcreads['R1'])),
-            '',
-            ])
+    if to_csv:
+        num_R1 = len(bcreads['R1'])
+        num_R2 = len(bcreads['R2'])
+        return(','.join([bc, str(retained), desc, str(consensus),
+                        str(num_R1), str(num_R2)]))
+    else:
+        return '\n'.join([
+                'BARCODE: {0}'.format(bc),
+                'RETAINED: {0}'.format(retained),
+                'DESCRIPTION: {0}'.format(desc),
+                'CONSENSUS: {0}'.format(consensus),
+                'R1 READS:\n\t{0}'.format('\n\t'.join(bcreads['R1'])),
+                'R2 READS:\n\t{0}'.format('\n\t'.join(bcreads['R1'])),
+                '',
+                ])
 
 
 def main():
@@ -71,7 +81,10 @@ def main():
             'bcstats':'_bcstats.csv',
             }
     if args['bcinfo']:
-        filesuffixes['bcinfo'] = '_bcinfo.txt.gz'
+        if args['bcinfo_csv']:
+            filesuffixes['bcinfo'] = '_bcinfo.csv.gz'
+        else:
+            filesuffixes['bcinfo'] = '_bcinfo.txt.gz'
     files = dict([(f, os.path.join(args['outdir'], '{0}{1}'.format(
             args['name'], s))) for (f, s) in filesuffixes.items()])
 
@@ -195,7 +208,8 @@ def main():
                 zip(r1files, r2files)])))
 
         # collect reads by barcode while iterating over reads
-        logger.info("Now parsing read pairs...")
+        logger.info("Now parsing read pairs test3...")
+        logger.info("here2")
         nreads = {
                 'total':0,
                 'fail filter':0,
@@ -305,6 +319,10 @@ def main():
         if args['bcinfo']:
             bcinfofile = gzip.open(files['bcinfo'], 'wt')
 
+        if args['bcinfo_csv']:
+            bcinfofile.write("Barcode,Retained,Description,Consensus,"
+                             "R1_Count,R2_Count")
+
         for (ibc, (bc, bcreads)) in enumerate(barcodes.items()):
 
             if (ibc + 1) % 2e5 == 0:
@@ -315,7 +333,8 @@ def main():
                 nbcs['too few reads'] += 1
                 if args['bcinfo']:
                     bcinfofile.write(bcInfo(bc, bcreads, retained=False, 
-                            consensus=None, desc='too few reads'))
+                            consensus=None, desc='too few reads',
+                            to_csv=args['bcinfo_csv']))
                 continue
 
             consensus = {}
@@ -345,9 +364,10 @@ def main():
 
                 if subamplicon:
                     if args['bcinfo']:
-                       bcinfofile.write(bcInfo(bc, bcreads, retained=True,
+                        bcinfofile.write(bcInfo(bc, bcreads, retained=True,
                             consensus=subamplicon, desc='aligned at '
-                            'position {0}'.format(refseqstart)))
+                            'position {0}'.format(refseqstart),
+                            to_csv=args['bcinfo_csv']))
                     nbcs['aligned'] += 1
                     dms_tools2.utils.incrementCounts(refseqstart,
                             subamplicon, args['chartype'], counts)
@@ -357,7 +377,8 @@ def main():
                 nbcs['not alignable'] += 1
                 if args['bcinfo']:
                     bcinfofile.write(bcInfo(bc, bcreads, retained=False,
-                            consensus=None, desc='could not align'))
+                            consensus=None, desc='could not align',
+                            to_csv=args['bcinfo_csv']))
 
         if args['bcinfo']:
             bcinfofile.close()

--- a/tests/test_bcsubamp.py
+++ b/tests/test_bcsubamp.py
@@ -451,6 +451,7 @@ class test_bcsubamp_trimreads(unittest.TestCase):
                     '--maxmuts', '0',
                     '--minfraccall', '1.0',
                     '--bcinfo',
+                    '--bcinfo_csv',
                     '--R1trim'] + r1trim + [
                     '--R2trim'] + r2trim
             sys.stderr.write('\nRunning:\n{0}\n'.format(

--- a/tests/test_bcsubamp.py
+++ b/tests/test_bcsubamp.py
@@ -312,7 +312,7 @@ class test_bcsubamp(unittest.TestCase):
                 '--maxmuts', str(self.MAXMUTS),
                 '--minfraccall', str(self.MINFRACCALL),
                 '--minconcur', str(self.MINCONCUR),
-                '--bcinfo',
+                '--bcinfo'
                ]
         if self.BCLEN2 is not None:
             cmds += ['--bclen2', str(self.bclen2)]
@@ -466,6 +466,12 @@ class test_bcsubamp_trimreads(unittest.TestCase):
                     bcstats.at[0, 'total'])
             self.assertEqual(aligned, bcstats.at[0, 'aligned'])
             self.assertEqual(unaligned, bcstats.at[0, 'not alignable'])
+
+            # check barcode info is expected csv
+            bcinfofile = '{0}/{1}_bcinfo.csv.gz'.format(self.testdir, name)
+            self.assertTrue(os.path.isfile(bcinfofile))
+            bcinfo = pandas.read_csv(bcinfofile)
+            self.assertEqual(bcstats.at[0, 'total'], len(bcinfo))
 
             # check on counts at each site
             countsfile = '{0}/{1}_codoncounts.csv'.format(


### PR DESCRIPTION
Added argument `--bcinfo_csv` to `dms2_bcsubamp` to allow the barcode info file to be output as a `.csv` rather than a `.txt` file. 

Added a small test to the `tests/test_bcsubamp.py`.

Note: `tests/test_batch_bcsubamp.py` does not test the output of `--bcinfo` or `--bcinfo_csv` (and did not previously), so I was not easily able to test the effect of the `--bcinfo_csv` option on `dms2_batch_bcsubamp`, but the changes here are at least compatible with the previous tests.