### PR TITLE
no need for max `biopython` version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Change Log
 
 2.6.7
 -----
-* Pin ``matplotlib``, ``pandas``, and ``biopython`` versions to avoid errors, and stop testing ``barcodeInfoToCodonVariantTable`` as ``dms_variants`` has incompatible versions.
+* Pin ``matplotlib``, ``pandas``, and ``plotnine`` versions to avoid errors, and stop testing ``barcodeInfoToCodonVariantTable`` as ``dms_variants`` has incompatible versions.
 
 2.6.6
 -----

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     license = 'GPLv3',
     install_requires = [
         'attrs>=17.4.0',
-        'biopython>=1.68,<1.78',
+        'biopython>=1.68',
         'pysam>=0.13',
         'pandas>=0.23,<1.0',
         'numpy>=1.16',


### PR DESCRIPTION
After merging #51, we no longer need to constrain `biopython` <1.78.