### PR TITLE
pin `numpy` < 1.20

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Change Log
 ===========
 
+2.6.10
+-------
+* Pin ``numpy`` to < 1.2 for this: https://github.com/numpy/numpy/issues/18355
+
 2.6.9
 -----
 * Pin ``pystan`` version to < 3.

--- a/dms_tools2/_metadata.py
+++ b/dms_tools2/_metadata.py
@@ -1,4 +1,4 @@
-__version__ = '2.6.9'
+__version__ = '2.6.10'
 __author__ = '`the Bloom Lab <https://github.com/jbloomlab/dms_tools2/graphs/contributors>`_'
 __url__ = 'http://jbloomlab.github.io/dms_tools2'
 __author_email__ = 'jbloom@fredhutch.org'

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'biopython>=1.68',
         'pysam>=0.13',
         'pandas>=0.23,<1.0',
-        'numpy>=1.16',
+        'numpy>=1.16,<1.20',  # https://github.com/numpy/numpy/issues/18355
         'IPython>=5.1',
         'jupyter>=1.0.0',
         'matplotlib>=2.1.1,<3.3',


### PR DESCRIPTION
Addresses this problem: https://github.com/numpy/numpy/issues/18355